### PR TITLE
okhttp-ws is no longer a separate module

### DIFF
--- a/src/main/resources/align-okhttp3.json
+++ b/src/main/resources/align-okhttp3.json
@@ -2,6 +2,7 @@
     "align": [
             {
                 "group": "com\\.squareup\\.okhttp3.*",
+                "excludes": ["okhttp-ws"],
                 "reason": "Align okhttp3",
                 "author": "Danny Thomas <dannyt@netflix.com>",
                 "date": "2016-10-26"


### PR DESCRIPTION
`okhttp3-ws` was removed as a separate module in commit [039bcf92](https://github.com/square/okhttp/commit/039bcf92dbff48d1162016f8cf4ba08a99071717) on 9/13/2016