### PR TITLE
Allow .pr1 releases for jackson

### DIFF
--- a/src/main/resources/align-jackson.json
+++ b/src/main/resources/align-jackson.json
@@ -4,7 +4,7 @@
                 "group": "com\\.fasterxml\\.jackson\\.(core|dataformat|datatype|jaxrs|jr|module)",
                 "excludes": ["jackson-datatype-jdk7", "jackson-module-scala_2.12", "jackson-module-scala_2.12.0-RC1", "jackson-module-scala_2.12.0-M5", "jackson-module-scala_2.12.0-M4", "jackson-module-scala_2.11", "jackson-module-scala_2.10", "jackson-module-scala_2.9.3", "jackson-module-scala_2.9.2", "jackson-module-scala_2.9.1", "jackson-module-swagger", "jackson-module-scala", "jackson-datatype-hibernate"],
                 "reason": "Align all Jackson libraries",
-                "match": "EXCLUDE_SUFFIXES",
+                "match": "^(\\d+\\.)?(\\d+\\.)?(\\*|\\d+)\\.?(pr\\d+)?",
                 "author": "Danny Thomas <dannyt@netflix.com>",
                 "date": "2016-05-19"
             }

--- a/src/test/groovy/VerifyRulesSpec.groovy
+++ b/src/test/groovy/VerifyRulesSpec.groovy
@@ -27,4 +27,32 @@ class VerifyRulesSpec extends IntegrationSpec {
         assert rulesFiles.size() > 0
         result.standardOutput.contains('a dependency rules source')
     }
+
+    def 'jackson pr1'() {
+        def rulesDir = new File('src/main/resources').absoluteFile
+        def rulesFiles = rulesDir.list()
+
+        buildFile << """
+        apply plugin: 'java'
+        apply plugin: 'nebula.resolution-rules'
+
+        repositories {
+            jcenter()
+        }
+
+        dependencies {
+            compile 'com.fasterxml.jackson.core:jackson-core:2.9.0.pr1'
+            compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.6'
+
+            resolutionRules fileTree('$rulesDir').include('align-jackson.json')
+        }
+        """
+
+        when:
+        def result = runTasksSuccessfully('dependencies', '--configuration', 'compile')
+
+        then:
+        assert rulesFiles.size() > 0
+        result.standardOutput.contains('com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.8.6 -> 2.9.0.pr1')
+    }
 }


### PR DESCRIPTION
Expands jackson align regex to allow `.pr1`