### PR TITLE
Exclude Netty and Protobuf Artifacts

### DIFF
--- a/src/main/resources/align-netty.json
+++ b/src/main/resources/align-netty.json
@@ -3,7 +3,7 @@
             {
                 "name": "align-netty",
                 "group": "io.netty",
-                "excludes": ["netty", "netty-(metrics-yammer|tcnative-boringssl-static|tcnative|tcnative-parent|microbench|codec-redis|codec-smtp|build|bom|testsuite-autobahn)"],
+                "excludes": ["netty", "netty-(metrics-yammer|tcnative-boringssl-static|tcnative|tcnative-parent|microbench|codec-redis|codec-smtp|build|bom|testsuite-autobahn|transport-native-unix-common|transport-native-kqueue|tarball|dev-tools)"],
                 "reason": "Align all Netty libraries",
                 "author": "Danny Thomas <dannyt@netflix.com>",
                 "date": "2016-04-28"

--- a/src/main/resources/align-protobuf.json
+++ b/src/main/resources/align-protobuf.json
@@ -3,7 +3,7 @@
             {
                 "name": "align-protobuf",
                 "group": "com.google.protobuf",
-                "includes": ["protobuf-java", "protobuf-java-util", "protobuf-parent", "protoc"],
+                "includes": ["protobuf-java", "protobuf-java-util", "protobuf-parent"],
                 "reason": "Align protobuf libraries",
                 "author": "Taylor Wicksell <taylor.wicksell+github.com@gmail.com>",
                 "date": "2017-02-07"


### PR DESCRIPTION
Both projects have previously-aligned artifacts missing at the latest version.