### PR TITLE
Remove springfox-staticdocs from alignment

### DIFF
--- a/src/main/resources/align-springfox.json
+++ b/src/main/resources/align-springfox.json
@@ -2,7 +2,7 @@
     "align": [
         {
             "group": "io.springfox",
-            "includes": ["springfox-(bean-validators|core|schema|spi|spring-web|staticdocs|swagger-common|swagger-ui|swagger2|)"],
+            "includes": ["springfox-(bean-validators|core|schema|spi|spring-web|swagger-common|swagger-ui|swagger2|)"],
             "reason": "Align Springfox libraries.",
             "author": "Remy Tiitre <remy.tiitre@lhv.ee>",
             "date": "2016-09-22"


### PR DESCRIPTION
It was not released with the rest of the 2.7.0 artifacts