### PR TITLE
Add protoc back to alignment

### DIFF
--- a/src/main/resources/align-protobuf.json
+++ b/src/main/resources/align-protobuf.json
@@ -3,7 +3,7 @@
             {
                 "name": "align-protobuf",
                 "group": "com.google.protobuf",
-                "includes": ["protobuf-java", "protobuf-java-util", "protobuf-parent"],
+                "includes": ["protobuf-java", "protobuf-java-util", "protobuf-parent", "protoc"],
                 "reason": "Align protobuf libraries",
                 "author": "Taylor Wicksell <taylor.wicksell+github.com@gmail.com>",
                 "date": "2017-02-07"


### PR DESCRIPTION
Recent versions of protobuf can align across these 4 artifacts again.