### PR TITLE
Adjust RegEx for align-spring

### DIFF
--- a/src/main/resources/align-spring.json
+++ b/src/main/resources/align-spring.json
@@ -4,7 +4,7 @@
             "group": "org\\.springframework",
             "includes": ["spring-(tx|aop|instrument|context-support|beans|jms|test|core|oxm|web|context|expression|aspects|websocket|framework-bom|webmvc|webmvc-portlet|jdbc|orm|instrument-tomcat|messaging)"],
             "excludes": [],
-            "match": "[2-9]\\.[0-9]\\.[0-9].RELEASE",
+            "match": "[2-9]\\.[0-9]+\\.[0-9]+.RELEASE",
             "reason": "Align Spring",
             "author": "Danny Thomas <dannyt@netflix.com>",
             "date": "2016-05-16"


### PR DESCRIPTION
The latest version of Spring 4 is "4.3.17.RELEASE" but this wasn't matched by the rule.