### PR TITLE
Align org.ow2.asm libraries

### DIFF
--- a/src/main/resources/align-asm.json
+++ b/src/main/resources/align-asm.json
@@ -1,0 +1,21 @@
+{
+  "align": [
+    {
+      "group": "org\\.ow2\\.asm",
+      "includes": [],
+      "excludes": [
+        "asm-all",
+        "asm-debug-all",
+        "asm-parent"
+      ],
+      "reason": "Align asm libraries.",
+      "author": "Steve Hill <sghill.dev@gmail.com>",
+      "date": "2018-07-28"
+    }
+  ],
+  "replace": [],
+  "substitute": [],
+  "deny": [],
+  "reject": [],
+  "exclude": []
+}


### PR DESCRIPTION
Simple alignment rule for the group. The [excluded modules](http://search.maven.org/#search|ga|1|g%3A%22org.ow2.asm%22) haven't been released in over a year.