### PR TITLE
Align servo libraries

### DIFF
--- a/src/main/resources/align-servo.json
+++ b/src/main/resources/align-servo.json
@@ -1,0 +1,17 @@
+{
+  "align": [
+    {
+      "group": "com\\.netflix\\.servo",
+      "includes": [],
+      "excludes": ["servo-internal", "servo-cloudwatch", "servo"],
+      "reason": "Align Servo libraries.",
+      "author": "Steve Hill <sghill.dev@gmail.com>",
+      "date": "2018-07-28"
+    }
+  ],
+  "replace": [],
+  "substitute": [],
+  "deny": [],
+  "reject": [],
+  "exclude": []
+}


### PR DESCRIPTION
Simple alignment rule for the group. [Excludes modules](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.netflix.servo%22) that are no longer released.