### PR TITLE
Align hibernate libraries

### DIFF
--- a/src/main/resources/align-hibernate-core.json
+++ b/src/main/resources/align-hibernate-core.json
@@ -1,0 +1,40 @@
+{
+  "align": [
+    {
+      "group": "org\\.hibernate",
+      "includes": [
+        "hibernate-agroal",
+        "hibernate-c3p0",
+        "hibernate-core",
+        "hibernate-ehcache",
+        "hibernate-entitymanager",
+        "hibernate-envers",
+        "hibernate-gradle-plugin",
+        "hibernate-hikaricp",
+        "hibernate-infinispan",
+        "hibernate-java8",
+        "hibernate-jcache",
+        "hibernate-jipijapa",
+        "hibernate-jpamodelgen",
+        "hibernate-orm-jbossmodules",
+        "hibernate-osgi",
+        "hibernate-proxool",
+        "hibernate-spatial",
+        "hibernate-testing",
+        "hibernate-tools",
+        "hibernate-tools-maven-plugin",
+        "hibernate-tools-parent",
+        "hibernate-vibur"
+      ],
+      "excludes": [],
+      "reason": "Align hibernate-core libraries.",
+      "author": "Steve Hill <sghill.dev@gmail.com>",
+      "date": "2018-07-28"
+    }
+  ],
+  "replace": [],
+  "substitute": [],
+  "deny": [],
+  "reject": [],
+  "exclude": []
+}

--- a/src/main/resources/align-hibernate-search.json
+++ b/src/main/resources/align-hibernate-search.json
@@ -1,0 +1,17 @@
+{
+  "align": [
+    {
+      "group": "org\\.hibernate",
+      "includes": ["hibernate-search", "hibernate-search-.*"],
+      "excludes": [],
+      "reason": "Align hibernate-search libraries.",
+      "author": "Steve Hill <sghill.dev@gmail.com>",
+      "date": "2018-07-28"
+    }
+  ],
+  "replace": [],
+  "substitute": [],
+  "deny": [],
+  "reject": [],
+  "exclude": []
+}

--- a/src/main/resources/align-hibernate-validator.json
+++ b/src/main/resources/align-hibernate-validator.json
@@ -1,0 +1,17 @@
+{
+  "align": [
+    {
+      "group": "org\\.hibernate",
+      "includes": ["hibernate-validator", "hibernate-validator-.*"],
+      "excludes": [],
+      "reason": "Align hibernate-validator libraries.",
+      "author": "Steve Hill <sghill.dev@gmail.com>",
+      "date": "2018-07-28"
+    }
+  ],
+  "replace": [],
+  "substitute": [],
+  "deny": [],
+  "reject": [],
+  "exclude": []
+}


### PR DESCRIPTION
Hibernate publishes three distinct families of artifacts under the same group.

The "core" rule aligns specifically named libraries that were released together last time around. The "validator" and "search" rules use the regex matchers.