### PR TITLE
Enable scala jackson

### DIFF
--- a/src/main/resources/align-jackson.json
+++ b/src/main/resources/align-jackson.json
@@ -2,7 +2,22 @@
     "align": [
             {
                 "group": "com\\.fasterxml\\.jackson\\.(core|dataformat|datatype|jaxrs|jr|module)",
-                "excludes": ["jackson-datatype-jdk7", "jackson-module-scala_2.12", "jackson-module-scala_2.12.0-RC1", "jackson-module-scala_2.12.0-M5", "jackson-module-scala_2.12.0-M4", "jackson-module-scala_2.11", "jackson-module-scala_2.10", "jackson-module-scala_2.9.3", "jackson-module-scala_2.9.2", "jackson-module-scala_2.9.1", "jackson-module-swagger", "jackson-module-scala", "jackson-datatype-hibernate", "jackson-dataformat-ion"],
+                "excludes": [
+                    "jackson-datatype-jdk7",
+                    "jackson-module-scala_2.12",
+                    "jackson-module-scala_2.12.0-RC1",
+                    "jackson-module-scala_2.12.0-M5",
+                    "jackson-module-scala_2.12.0-M4",
+                    "jackson-module-scala_2.11",
+                    "jackson-module-scala_2.10",
+                    "jackson-module-scala_2.9.3",
+                    "jackson-module-scala_2.9.2",
+                    "jackson-module-scala_2.9.1",
+                    "jackson-module-swagger",
+                    "jackson-module-scala",
+                    "jackson-datatype-hibernate",
+                    "jackson-dataformat-ion"
+                ],
                 "includes": [],
                 "reason": "Align all Jackson libraries",
                 "match": "^(\\d+\\.)?(\\d+\\.)?(\\*|\\d+)?(\\.pr\\d+)?",

--- a/src/main/resources/align-jackson.json
+++ b/src/main/resources/align-jackson.json
@@ -4,12 +4,9 @@
                 "group": "com\\.fasterxml\\.jackson\\.(core|dataformat|datatype|jaxrs|jr|module)",
                 "excludes": [
                     "jackson-datatype-jdk7",
-                    "jackson-module-scala_2.12",
                     "jackson-module-scala_2.12.0-RC1",
                     "jackson-module-scala_2.12.0-M5",
                     "jackson-module-scala_2.12.0-M4",
-                    "jackson-module-scala_2.11",
-                    "jackson-module-scala_2.10",
                     "jackson-module-scala_2.9.3",
                     "jackson-module-scala_2.9.2",
                     "jackson-module-scala_2.9.1",


### PR DESCRIPTION
These modules all exist at the most recent versions of jackson, so this change will allow these libraries to align.