### PR TITLE
Add a replacement rule for javax.validation:validation-api

### DIFF
--- a/src/main/resources/replace-javax.json
+++ b/src/main/resources/replace-javax.json
@@ -1,0 +1,16 @@
+{
+  "replace" : [
+    {
+      "module" : "javax.validation:validation-api",
+      "with" : "jakarta.validation:jakarta.validation-api",
+      "reason" : "Jakarta is replacing javax. This avoids having both on the classpath which helps to align the versions",
+      "author" : "Asi Bross",
+      "date" : "2020-01-24T00:00:00.000Z"
+    }
+  ],
+  "align": [],
+  "substitute": [],
+  "deny": [],
+  "exclude": [],
+  "reject": []
+}


### PR DESCRIPTION
As more libraries adopt Jakarta maven coordinates over Javax, we will run into situation where both the javax and jakarta dependencies exists on the classpath but with different versions, and version resolutions fails to align. This may result in exception of type MethodNotFound and its likings.
The first encounter we have seen is in SB 2.2 which has a dependency on `jakarta.validation:jakarta.validation-api` and other libraries such as swagger-core having a dependency on `javax.validation:validation-api`.