### PR TITLE
Align Confluent Kafka Libraries

### DIFF
--- a/src/main/resources/align-confluent-kafka.json
+++ b/src/main/resources/align-confluent-kafka.json
@@ -1,0 +1,18 @@
+{
+    "align": [
+        {
+            "name": "align-archaius2",
+            "group": "io\\.confluent",
+            "includes": ["kafka-.*"],
+            "excludes": [],
+            "reason": "Align Confluent Kafka libraries",
+            "author": "Richard Fussenegger <fleshgrinder@users.noreply.github.com>",
+            "date": "2022-01-10"
+        }
+    ],
+    "replace": [],
+    "substitute": [],
+    "deny": [],
+    "exclude": [],
+    "reject": []
+}


### PR DESCRIPTION
Another vendor who releases a lot of libraries that need to match but does not provide a BOM. The situation here is actually even more complicated than this, because their libraries also have requirements towards the used Kafka library (see [Confluent version interoperability](https://docs.confluent.io/platform/current/installation/versions-interoperability.html)). In theory, it would be possible to express this with Gradle, but they destroy this by also releasing alternative Kafka libraries under the same coordinates with two additional versioning schemes. 🙄 Anyway, we could not add this required metadata as part of this plugin even if that would not be the case.

**Note** that these libraries are not published to Maven Central and only available via the [Confluent Repository](https://mvnrepository.com/repos/confluent-packages). I do not know if this means that this rule is out of scope for this plugin. These dependencies are often used together with Kafka.