### PR TITLE
Substitute snakeyaml 1.30 -> 1.29

### DIFF
--- a/src/integTest/groovy/nebula/plugin/resolutionrules/SubstituteSnakeyamlSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/SubstituteSnakeyamlSpec.groovy
@@ -1,0 +1,53 @@
+package nebula.plugin.resolutionrules
+
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.Unroll
+
+class SubstituteSnakeyamlSpec extends RulesBaseSpecification {
+    def setup() {
+        def ruleFile = new File(getClass().getResource('/substitute-snakeyaml.json').toURI())
+        buildFile << """\
+            dependencies {
+                resolutionRules files('${ruleFile.absolutePath}')
+            }
+            """.stripIndent()
+    }
+
+    @Unroll
+    def 'substitute version from #snakeyamlVersion to 1.29'() {
+        given:
+        buildFile << """\
+            dependencies {
+                implementation "org.yaml:snakeyaml:${snakeyamlVersion}"
+            }
+            """.stripIndent()
+
+        when:
+        BuildResult result = runWithArgumentsSuccessfully('dependencies', '--configuration', 'compileClasspath')
+
+        then:
+        result.output.contains "org.yaml:snakeyaml:1.30 -> 1.29"
+
+        where:
+        snakeyamlVersion << ['1.30']
+    }
+
+    @Unroll
+    def 'do not substitute other versions'() {
+        given:
+        buildFile << """\
+            dependencies {
+                implementation "org.yaml:snakeyaml:${snakeyamlVersion}"
+            }
+            """.stripIndent()
+
+        when:
+        BuildResult result = runWithArgumentsSuccessfully('dependencies', '--configuration', 'compileClasspath')
+
+        then:
+        result.output.contains "org.yaml:snakeyaml:1.29"
+
+        where:
+        snakeyamlVersion << ['1.29']
+    }
+}

--- a/src/main/resources/substitute-snakeyaml.json
+++ b/src/main/resources/substitute-snakeyaml.json
@@ -1,0 +1,16 @@
+{
+    "align": [],
+    "deny": [],
+    "exclude": [],
+    "reject": [],
+    "replace": [],
+    "substitute": [
+        {
+            "module": "org.yaml:snakeyaml:1.30",
+            "with": "org.yaml:snakeyaml:1.29",
+            "reason": "release 1.30 is missing 'android' (classifier) variant jar",
+            "author": "Aubrey Chipman",
+            "date": "2022-04-13"
+        }
+    ]
+}


### PR DESCRIPTION
because 1.30 is missing the 'android' classifier

See related issues:
- https://bitbucket.org/snakeyaml/snakeyaml/issues/519/release-130-is-missing-android-classifier
- https://github.com/spring-projects/spring-boot/issues/30586
- https://github.com/gradle/gradle/issues/20417