### PR TITLE
Optional rule to substitute graphql-java that works with Spring Boot 2.x

### DIFF
--- a/src/main/resources/optional-substitute-graphql-java.json
+++ b/src/main/resources/optional-substitute-graphql-java.json
@@ -1,0 +1,16 @@
+{
+    "align": [],
+    "deny": [],
+    "exclude": [],
+    "reject": [],
+    "replace": [],
+    "substitute": [
+        {
+            "module": "com.graphql-java:graphql-java-extended-validation:17.0",
+            "with": "com.graphql-java:graphql-java-extended-validation:17.0-hibernate-validator-6.2.0.Final",
+            "reason": "This version is compatible with JEE 8 and Hibernate Validator 6.2 which are compatible with Spring Boot 2.x",
+            "author": "Aubrey Chipman",
+            "date": "2022-04-26"
+        }
+    ]
+}


### PR DESCRIPTION
See related commit: https://github.com/Netflix/dgs-framework/commit/1cb89da2152655b9e6350c012a54a2754cc164c2