### PR TITLE
add alignment rule for AWS SDK for Java V2

### DIFF
--- a/src/integTest/groovy/nebula/plugin/resolutionrules/AlignAwsSdkJavaV2Spec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/AlignAwsSdkJavaV2Spec.groovy
@@ -1,0 +1,38 @@
+package nebula.plugin.resolutionrules
+
+import org.gradle.testkit.runner.BuildResult
+
+class AlignAwsSdkJavaV2Spec extends RulesBaseSpecification {
+
+    def setup() {
+        def resolutionRulesFile = getClass().getClassLoader().getResource('align-aws-sdk-java-v2.json')
+        buildFile << """
+            dependencies {
+              resolutionRules files('$resolutionRulesFile')
+            }
+            """.stripIndent()
+    }
+
+    def 'can align software.amazon.awssdk libraries'() {
+        given:
+        buildFile << """\
+            dependencies {
+              implementation 'software.amazon.awssdk:aws-core:2.22.0'
+              implementation 'software.amazon.awssdk:ec2:2.23.9'
+              implementation 'software.amazon.awssdk:sqs:2.20.136'
+            }
+            """.stripIndent()
+
+        when:
+        BuildResult result = runWithArgumentsSuccessfully('dI', '--dependency', 'software.amazon.awssdk')
+
+        then:
+        result.output.contains('By constraint: belongs to platform aligned-platform:align-aws-sdk-java-v2-0-for-software.amazon.awssdk:2.23.9')
+        def alignedVersion = "2.23.9"
+        // aligned
+        result.output.contains("software.amazon.awssdk:aws-core:$alignedVersion\n")
+        result.output.contains("software.amazon.awssdk:ec2:$alignedVersion\n")
+        result.output.contains("software.amazon.awssdk:sqs:$alignedVersion\n")
+        !result.output.contains('FAILED')
+    }
+}

--- a/src/main/resources/align-aws-sdk-java-v2.json
+++ b/src/main/resources/align-aws-sdk-java-v2.json
@@ -1,0 +1,18 @@
+{
+  "align": [
+    {
+      "name": "align-aws-sdk-java-v2",
+      "group": "software.amazon.awssdk",
+      "includes": [".*"],
+      "excludes": [],
+      "reason": "Align AWS SDK for Java V2 libraries",
+      "author": "Brian Harrington <brharrington@netflix.com>",
+      "date": "2024-01-30T19:53:46.000Z"
+    }
+  ],
+  "replace": [],
+  "substitute": [],
+  "deny": [],
+  "exclude": [],
+  "reject": []
+}

--- a/src/main/resources/align-aws-sdk-java-v2.json
+++ b/src/main/resources/align-aws-sdk-java-v2.json
@@ -3,7 +3,7 @@
     {
       "name": "align-aws-sdk-java-v2",
       "group": "software.amazon.awssdk",
-      "includes": [".*"],
+      "includes": [],
       "excludes": [],
       "reason": "Align AWS SDK for Java V2 libraries",
       "author": "Brian Harrington <brharrington@netflix.com>",


### PR DESCRIPTION
There is already a rule for the V1 SDK, but more stuff is moving to the V2 SDK.