### PR TITLE
Add Apache Groovy alignment and replacement

### DIFF
--- a/src/integTest/groovy/nebula/plugin/resolutionrules/GroovyIntegrationSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/GroovyIntegrationSpec.groovy
@@ -1,0 +1,151 @@
+package nebula.plugin.resolutionrules
+
+import org.gradle.testkit.runner.BuildResult
+
+class GroovyIntegrationSpec extends RulesBaseSpecification {
+    def setup() {
+        buildFile << """\
+            dependencies {
+                resolutionRules files('${new File('src/main/resources/align-groovy.json').absolutePath}', '${new File('src/main/resources/align-apache-groovy.json').absolutePath}', '${new File('src/main/resources/replace-groovy.json').absolutePath}')
+            }
+            """.stripIndent()
+    }
+
+    def 'check replacement works'() {
+        buildFile << '''\
+            dependencies {
+                implementation 'org.codehaus.groovy:groovy:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-all:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-ant:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-astbuilder:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-backports-compat23:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-binary:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-bom:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-bsf:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-cli-commons:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-cli-picocli:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-console:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-contracts:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-datetime:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-dateutil:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-docgenerator:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-ginq:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-groovydoc:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-groovysh:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-jaxb:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-jmx:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-json:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-jsr223:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-macro:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-macro-library:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-nio:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-servlet:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-sql:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-swing:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-templates:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-test:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-test-junit5:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-testng:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-toml:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-typecheckers:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-xml:3.0.22'
+                implementation 'org.codehaus.groovy:groovy-yaml:3.0.22'
+
+                implementation 'org.apache.groovy:groovy:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-all:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-ant:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-astbuilder:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-backports-compat23:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-binary:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-bom:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-bsf:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-cli-commons:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-cli-picocli:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-console:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-contracts:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-datetime:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-dateutil:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-docgenerator:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-ginq:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-groovydoc:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-groovysh:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-jaxb:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-jmx:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-json:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-jsr223:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-macro:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-macro-library:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-nio:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-servlet:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-sql:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-swing:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-templates:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-test:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-test-junit5:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-testng:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-toml:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-typecheckers:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-xml:4.0.0-alpha-1'
+                implementation 'org.apache.groovy:groovy-yaml:4.0.0-alpha-1'
+            }
+            '''.stripIndent()
+
+        when:
+        BuildResult result = runWithArgumentsSuccessfully('dependencies', '--configuration', 'compileClasspath')
+
+        then:
+        result.output.contains('org.codehaus.groovy:groovy:3.0.22 -> org.apache.groovy:groovy:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-all:3.0.22 -> org.apache.groovy:groovy-all:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-ant:3.0.22 -> org.apache.groovy:groovy-ant:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-astbuilder:3.0.22 -> org.apache.groovy:groovy-astbuilder:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-backports-compat23:3.0.22 -> org.apache.groovy:groovy-backports-compat23:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-binary:3.0.22 -> org.apache.groovy:groovy-binary:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-bom:3.0.22 -> org.apache.groovy:groovy-bom:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-bsf:3.0.22 -> org.apache.groovy:groovy-bsf:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-cli-commons:3.0.22 -> org.apache.groovy:groovy-cli-commons:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-cli-picocli:3.0.22 -> org.apache.groovy:groovy-cli-picocli:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-console:3.0.22 -> org.apache.groovy:groovy-console:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-contracts:3.0.22 -> org.apache.groovy:groovy-contracts:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-datetime:3.0.22 -> org.apache.groovy:groovy-datetime:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-dateutil:3.0.22 -> org.apache.groovy:groovy-dateutil:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-docgenerator:3.0.22 -> org.apache.groovy:groovy-docgenerator:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-ginq:3.0.22 -> org.apache.groovy:groovy-ginq:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-groovydoc:3.0.22 -> org.apache.groovy:groovy-groovydoc:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-groovysh:3.0.22 -> org.apache.groovy:groovy-groovysh:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-jaxb:3.0.22 -> org.apache.groovy:groovy-jaxb:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-jmx:3.0.22 -> org.apache.groovy:groovy-jmx:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-json:3.0.22 -> org.apache.groovy:groovy-json:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-jsr223:3.0.22 -> org.apache.groovy:groovy-jsr223:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-macro:3.0.22 -> org.apache.groovy:groovy-macro:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-macro-library:3.0.22 -> org.apache.groovy:groovy-macro-library:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-nio:3.0.22 -> org.apache.groovy:groovy-nio:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-servlet:3.0.22 -> org.apache.groovy:groovy-servlet:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-sql:3.0.22 -> org.apache.groovy:groovy-sql:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-swing:3.0.22 -> org.apache.groovy:groovy-swing:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-templates:3.0.22 -> org.apache.groovy:groovy-templates:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-test:3.0.22 -> org.apache.groovy:groovy-test:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-test-junit5:3.0.22 -> org.apache.groovy:groovy-test-junit5:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-testng:3.0.22 -> org.apache.groovy:groovy-testng:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-toml:3.0.22 -> org.apache.groovy:groovy-toml:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-typecheckers:3.0.22 -> org.apache.groovy:groovy-typecheckers:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-xml:3.0.22 -> org.apache.groovy:groovy-xml:4.0.0-alpha-1')
+        result.output.contains('org.codehaus.groovy:groovy-yaml:3.0.22 -> org.apache.groovy:groovy-yaml:4.0.0-alpha-1')
+    }
+
+    def 'check alignment works'() {
+        buildFile << '''\
+            dependencies {
+                implementation 'org.codehaus.groovy:groovy-toml:3.0.22'
+                implementation 'org.apache.groovy:groovy:4.0.22'
+                implementation 'org.apache.groovy:groovy-toml:4.0.0-alpha-1'
+            }
+            '''.stripIndent()
+
+        when:
+        BuildResult result = runWithArgumentsSuccessfully('dependencies', '--configuration', 'compileClasspath')
+
+        then:
+        result.output.contains('org.apache.groovy:groovy:4.0.22')
+        result.output.contains('org.codehaus.groovy:groovy-toml:3.0.22 -> org.apache.groovy:groovy-toml:4.0.22')
+    }
+}

--- a/src/main/resources/align-apache-groovy.json
+++ b/src/main/resources/align-apache-groovy.json
@@ -1,0 +1,17 @@
+{
+    "align": [
+        {
+            "group": "org\\.apache\\.groovy",
+            "includes": [],
+            "excludes": [],
+            "reason": "Align Apache Groovy libraries",
+            "author": "Danny Thomas <dannyt@netflix.com>",
+            "date": "2024-07-17"
+        }
+    ],
+    "replace": [],
+    "substitute": [],
+    "deny": [],
+    "exclude": [],
+    "reject": []
+}

--- a/src/main/resources/replace-groovy.json
+++ b/src/main/resources/replace-groovy.json
@@ -1,0 +1,520 @@
+{
+    "replace" : [
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:$package",
+            "with" : "org.apache.groovy:$package",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy",
+            "with" : "org.apache.groovy:groovy",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-all",
+            "with" : "org.apache.groovy:groovy-all",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-ant",
+            "with" : "org.apache.groovy:groovy-ant",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-astbuilder",
+            "with" : "org.apache.groovy:groovy-astbuilder",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-backports-compat23",
+            "with" : "org.apache.groovy:groovy-backports-compat23",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-binary",
+            "with" : "org.apache.groovy:groovy-binary",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-bom",
+            "with" : "org.apache.groovy:groovy-bom",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-bsf",
+            "with" : "org.apache.groovy:groovy-bsf",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-cli-commons",
+            "with" : "org.apache.groovy:groovy-cli-commons",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-cli-picocli",
+            "with" : "org.apache.groovy:groovy-cli-picocli",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-console",
+            "with" : "org.apache.groovy:groovy-console",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-contracts",
+            "with" : "org.apache.groovy:groovy-contracts",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-datetime",
+            "with" : "org.apache.groovy:groovy-datetime",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-dateutil",
+            "with" : "org.apache.groovy:groovy-dateutil",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-docgenerator",
+            "with" : "org.apache.groovy:groovy-docgenerator",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-ginq",
+            "with" : "org.apache.groovy:groovy-ginq",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-groovydoc",
+            "with" : "org.apache.groovy:groovy-groovydoc",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-groovysh",
+            "with" : "org.apache.groovy:groovy-groovysh",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-jaxb",
+            "with" : "org.apache.groovy:groovy-jaxb",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-jmx",
+            "with" : "org.apache.groovy:groovy-jmx",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-json",
+            "with" : "org.apache.groovy:groovy-json",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-jsr223",
+            "with" : "org.apache.groovy:groovy-jsr223",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-macro",
+            "with" : "org.apache.groovy:groovy-macro",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-macro-library",
+            "with" : "org.apache.groovy:groovy-macro-library",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-nio",
+            "with" : "org.apache.groovy:groovy-nio",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-servlet",
+            "with" : "org.apache.groovy:groovy-servlet",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-sql",
+            "with" : "org.apache.groovy:groovy-sql",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-swing",
+            "with" : "org.apache.groovy:groovy-swing",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-templates",
+            "with" : "org.apache.groovy:groovy-templates",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-test",
+            "with" : "org.apache.groovy:groovy-test",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-test-junit5",
+            "with" : "org.apache.groovy:groovy-test-junit5",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-testng",
+            "with" : "org.apache.groovy:groovy-testng",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-toml",
+            "with" : "org.apache.groovy:groovy-toml",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-typecheckers",
+            "with" : "org.apache.groovy:groovy-typecheckers",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-xml",
+            "with" : "org.apache.groovy:groovy-xml",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        },
+        {
+            "module" : "org.codehaus.groovy:groovy-yaml",
+            "with" : "org.apache.groovy:groovy-yaml",
+            "reason" : "The groovy group id changed for 4.0 and later",
+            "author" : "Danny Thomas",
+            "date" : "2024-07-17"
+        }
+    ],
+    "align": [],
+    "substitute": [],
+    "deny": [],
+    "exclude": [],
+    "reject": []
+}


### PR DESCRIPTION
We had a report of a classpath duplication between Groovy 3 and 4, this adds alignment and replacement to avoid that.