### PR TITLE
Update jackson alignment rule for 2.20

### DIFF
--- a/src/integTest/groovy/nebula/plugin/resolutionrules/AlignJacksonSpec.groovy
+++ b/src/integTest/groovy/nebula/plugin/resolutionrules/AlignJacksonSpec.groovy
@@ -1,0 +1,70 @@
+package nebula.plugin.resolutionrules
+
+import org.gradle.testkit.runner.BuildResult
+
+class AlignJacksonSpec extends RulesBaseSpecification {
+
+    def setup() {
+        def resolutionRulesFile = getClass().getClassLoader().getResource('align-jackson.json')
+        buildFile << """
+            dependencies {
+              resolutionRules files('$resolutionRulesFile')
+            }
+            """.stripIndent()
+    }
+
+    def 'can align jackson 2.x libraries'() {
+        given:
+        buildFile << """\
+            dependencies {
+              implementation 'com.fasterxml.jackson.core:jackson-core:2.19.1'
+              implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.0'
+              implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.0'
+              implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.19.0'
+            }
+            """.stripIndent()
+
+        when:
+        BuildResult result = runWithArgumentsSuccessfully('dI', '--dependency', 'com.fasterxml.jackson')
+
+        then:
+        result.output.contains('By constraint: belongs to platform aligned-platform:align-jackson-0-for-com.fasterxml.jackson.core-or-dataformat-or-datatype-or-jaxrs-or-jr-or-module:2.19.1')
+        def alignedVersion = "2.19.1"
+        // aligned
+        result.output.contains("com.fasterxml.jackson.core:jackson-core:$alignedVersion\n")
+        result.output.contains("com.fasterxml.jackson.core:jackson-annotations:$alignedVersion\n")
+        result.output.contains("com.fasterxml.jackson.core:jackson-databind:$alignedVersion\n")
+        result.output.contains("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$alignedVersion\n")
+        !result.output.contains('FAILED')
+    }
+
+    def 'can align jackson 2.20.x libraries with annotations change'() {
+        // 2.20.x dropped the patch version for the annotations library:
+        // https://github.com/FasterXML/jackson-annotations/issues/294
+
+        given:
+        buildFile << """\
+            dependencies {
+              implementation enforcedPlatform('com.fasterxml.jackson:jackson-bom:2.20.0')
+              implementation 'com.fasterxml.jackson.core:jackson-core:2.20.0'
+              implementation 'com.fasterxml.jackson.core:jackson-annotations:2.17.0'
+              implementation 'com.fasterxml.jackson.core:jackson-databind:2.18.0'
+              implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.19.0'
+            }
+            """.stripIndent()
+
+        when:
+        BuildResult result = runWithArgumentsSuccessfully('dI', '--dependency', 'com.fasterxml.jackson')
+
+        then:
+        result.output.contains('By constraint: belongs to platform aligned-platform:align-jackson-0-for-com.fasterxml.jackson.core-or-dataformat-or-datatype-or-jaxrs-or-jr-or-module:2.20.0')
+        def alignedVersion = "2.20.0"
+        def alignedVersionAnno = "2.20"
+        // aligned
+        result.output.contains("com.fasterxml.jackson.core:jackson-core:$alignedVersion\n")
+        result.output.contains("com.fasterxml.jackson.core:jackson-annotations:$alignedVersionAnno\n")
+        result.output.contains("com.fasterxml.jackson.core:jackson-databind:$alignedVersion\n")
+        result.output.contains("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$alignedVersion\n")
+        !result.output.contains('FAILED')
+    }
+}

--- a/src/main/resources/align-jackson.json
+++ b/src/main/resources/align-jackson.json
@@ -3,6 +3,7 @@
             {
                 "group": "com\\.fasterxml\\.jackson\\.(core|dataformat|datatype|jaxrs|jr|module)",
                 "excludes": [
+                    "jackson-annotations",
                     "jackson-datatype-jdk7",
                     "jackson-module-scala_2.12.0-RC1",
                     "jackson-module-scala_2.12.0-M5",


### PR DESCRIPTION
There was a change in 2.20.x for the `jackson-annotations` library. It no longer includes the patch version ([#294]). Add it to the exclude list to avoid trying to align with the patch versions of other jackson projects. If the other projects are aligned, `jackson-annotations` should be handled correctly with the normal dependency resolution.

[#294]: https://github.com/FasterXML/jackson-annotations/issues/294